### PR TITLE
chore: add unit test for Entity

### DIFF
--- a/google/cloud/documentai_toolbox/wrappers/entity.py
+++ b/google/cloud/documentai_toolbox/wrappers/entity.py
@@ -35,8 +35,8 @@ class Entity:
             the document, this field will be empty.
     """
     documentai_entity: documentai.Document.Entity = dataclasses.field(repr=False)
-    type_: str = dataclasses.field(init=False, repr=False)
-    mention_text: str = dataclasses.field(init=False, repr=False, default="")
+    type_: str = dataclasses.field(init=False)
+    mention_text: str = dataclasses.field(init=False, default="")
 
     def __post_init__(self):
         self.type_ = self.documentai_entity.type_

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -20,8 +20,7 @@ from google.cloud.documentai_toolbox import entity
 
 def test_Entity():
     documentai_entity = documentai.Document.Entity(
-        type_="some_entity_type",
-        mention_text="some_mention_text"
+        type_="some_entity_type", mention_text="some_mention_text"
     )
     wrapper_entity = entity.Entity(documentai_entity)
 

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -13,3 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from google.cloud import documentai
+from google.cloud.documentai_toolbox import entity
+
+
+def test_Entity():
+    documentai_entity = documentai.Document.Entity(
+        type_="some_entity_type",
+        mention_text="some_mention_text"
+    )
+    wrapper_entity = entity.Entity(documentai_entity)
+
+    assert wrapper_entity.type_ == "some_entity_type"
+    assert wrapper_entity.mention_text == "some_mention_text"


### PR DESCRIPTION
add a unit test for documentai_toolbox.wrappers.entity.Entity.

Also remove `repr=False` from the `type_` and `mention_text` fields from that class for simpler debugging.