### PR TITLE
chore: Add `PythonDependency` to `auto-approve.yml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@
 
 # @googleapis/python-samples-reviewers @googleapis/cdpe-cloudai are the default owners for samples changes
 /samples/   @googleapis/python-samples-reviewers @googleapis/cdpe-cloudai
+/samples/snippets/requirements.txt   @yoshi-approver

--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,3 +1,4 @@
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
 processes:
+  - "PythonDependency"
   - "OwlBotTemplateChanges"


### PR DESCRIPTION
- Add @yoshi-approver as CODEOWNER for `/samples/snippets/requirements.txt`

NOTE: This only auto-approves dependencies for Samples, not the toolbox itself
