### PR TITLE
fix: Empty Page SubElements

### DIFF
--- a/google/cloud/documentai_toolbox/wrappers/page.py
+++ b/google/cloud/documentai_toolbox/wrappers/page.py
@@ -122,7 +122,7 @@ class BasePageElement(ABC):
         """
         if self._text is None:
             self._text = _text_from_layout(
-                layout=self.documentai_object.layout, text=self._page.text
+                layout=self.documentai_object.layout, text=self._page.document_text
             )
         return self._text
 

--- a/google/cloud/documentai_toolbox/wrappers/page.py
+++ b/google/cloud/documentai_toolbox/wrappers/page.py
@@ -324,13 +324,15 @@ def _text_from_layout(layout: documentai.Document.Page.Layout, text: str) -> str
             Required. an element with layout fields.
         text (str):
             Required. UTF-8 encoded text in reading order
-            from the document.
+            of the `documentai.Document` containing the layout element.
 
     Returns:
         str:
             Text from a single element.
     """
 
+    # Note: `layout.text_anchor.text_segments` are indexes into the full Document text.
+    # https://cloud.google.com/document-ai/docs/reference/rest/v1/Document#textsegment
     return "".join(
         text[int(segment.start_index) : int(segment.end_index)]
         for segment in layout.text_anchor.text_segments

--- a/tests/unit/test_page.py
+++ b/tests/unit/test_page.py
@@ -31,6 +31,16 @@ def docproto():
 
 
 @pytest.fixture
+def large_docproto():
+    with open(
+        "tests/unit/resources/multi_page/pretrained-ocr-v1.0-2020-09-23_output.json",
+        "r",
+        encoding="utf-8",
+    ) as f:
+        return documentai.Document.from_json(f.read())
+
+
+@pytest.fixture
 def docproto_with_symbols():
     with open(
         "tests/unit/resources/toolbox_invoice_test-with-symbols.json",
@@ -245,6 +255,21 @@ def test_Paragraph(docproto):
     # checking cached value
     assert paragraph.text == "Invoice\n"
     assert paragraph.hocr_bounding_box == "bbox 1310 220 1534 282"
+
+
+def test_page_elements_large_document(large_docproto):
+    for pg in large_docproto.pages:
+        wrapped_page = page.Page(
+            documentai_object=pg, document_text=large_docproto.text
+        )
+        for block in wrapped_page.blocks:
+            assert block.text != ""
+        for paragraph in wrapped_page.paragraphs:
+            assert paragraph.text != ""
+        for line in wrapped_page.lines:
+            assert line.text != ""
+        for token in wrapped_page.tokens:
+            assert token.text != ""
 
 
 def test_Line(docproto):


### PR DESCRIPTION
- Changed page elements to be initalized with document text instead of page text.
  - Caused all paragraphs/blocks/etc after the first page to be empty.
- Introduced in https://github.com/googleapis/python-documentai-toolbox/pull/123
  - https://github.com/googleapis/python-documentai-toolbox/pull/123/files#diff-af92c6de8f8e84ca66d2fb9fa7e9bddb5bd644e944153bf7a78d35f47c05853eR251
- Added new Unit test which covers the issue
- Discovered in https://github.com/GoogleCloudPlatform/generative-ai/issues/217
