### PR TITLE
fix: Escape html special characters in hocr_document_template.xml.j2

### DIFF
--- a/google/cloud/documentai_toolbox/templates/hocr_document_template.xml.j2
+++ b/google/cloud/documentai_toolbox/templates/hocr_document_template.xml.j2
@@ -19,9 +19,9 @@
             {% set paridx = loop.index0 -%}
             <p class='ocr_par' id='par_{{ page_number }}_{{ bidx }}_{{ paridx }}' title='{{ paragraph.hocr_bounding_box -}}'>{% for line in paragraph.lines -%}
                 {% set lidx = loop.index0 -%}
-                <span class='ocr_line' id='line_{{ page_number }}_{{ bidx }}_{{ paridx }}_{{ lidx }}' title='{{ line.hocr_bounding_box }}'>{{ line.text }}{% for token in line.tokens -%}
+                <span class='ocr_line' id='line_{{ page_number }}_{{ bidx }}_{{ paridx }}_{{ lidx }}' title='{{ line.hocr_bounding_box }}'>{{ line.text|escape }}{% for token in line.tokens -%}
                     {% set tidx = loop.index0 -%}
-                    <span class='ocrx_word' id='word_{{ page_number }}_{{ bidx }}_{{ paridx }}_{{ lidx }}_{{ tidx }}' title='{{ token.hocr_bounding_box }}'>{{ token.text }}</span>{% endfor -%}
+                    <span class='ocrx_word' id='word_{{ page_number }}_{{ bidx }}_{{ paridx }}_{{ lidx }}_{{ tidx }}' title='{{ token.hocr_bounding_box }}'>{{ token.text|escape }}</span>{% endfor -%}
                 </span>{% endfor -%}
             </p>{% endfor -%}
         </span>{% endfor -%}


### PR DESCRIPTION
Special characters need to be escaped in order to utilize the output from the HOCR conversion in other tools. The j2 spec also suggests to escape characters (see HTML escaping at https://jinja.palletsprojects.com/en/3.0.x/templates/)

Fixes #213 🦕