### PR TITLE
fix: Add trailing slash if not present for `gcs_prefix` in `Document.from_gcs()` to cover matching prefixes edge case.

### DIFF
--- a/google/cloud/documentai_toolbox/wrappers/document.py
+++ b/google/cloud/documentai_toolbox/wrappers/document.py
@@ -504,6 +504,8 @@ class Document:
             Document:
                 A document from gcs.
         """
+        # Add trailing slash if not present.
+        gcs_prefix = gcs_prefix.rstrip("/") + "/"
         shards = _get_shards(gcs_bucket_name=gcs_bucket_name, gcs_prefix=gcs_prefix)
         return cls(
             shards=shards,

--- a/samples/snippets/quickstart_sample.py
+++ b/samples/snippets/quickstart_sample.py
@@ -52,7 +52,7 @@ def quickstart_sample(
     documentai_document: Optional[documentai.Document] = None,
     batch_process_metadata: Optional[documentai.BatchProcessMetadata] = None,
     batch_process_operation: Optional[str] = None,
-) -> None:
+) -> document.Document:
     if gcs_bucket_name and gcs_prefix:
         # Load from Google Cloud Storage Directory
         print("Document structure in Cloud Storage")
@@ -128,5 +128,6 @@ def quickstart_sample(
         if entity.normalized_text:
             print(f"\tNormalized Text: {entity.normalized_text}")
 
+    # [END documentai_toolbox_quickstart]
 
-# [END documentai_toolbox_quickstart]
+    return wrapped_document

--- a/samples/snippets/test_quickstart_sample.py
+++ b/samples/snippets/test_quickstart_sample.py
@@ -96,6 +96,35 @@ def test_quickstart_sample_batch_process_metadata(
     assert "Document Successfully Loaded!" in out
 
 
+def test_quickstart_sample_batch_process_metadata_matching_prefixes(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    batch_process_metadata = documentai.BatchProcessMetadata(
+        state=documentai.BatchProcessMetadata.State.SUCCEEDED,
+        individual_process_statuses=[
+            documentai.BatchProcessMetadata.IndividualProcessStatus(
+                input_gcs_source="gs://test-directory/documentai/input.pdf",
+                output_gcs_destination="gs://documentai_toolbox_samples/output/matching-prefixes/1",
+            ),
+            documentai.BatchProcessMetadata.IndividualProcessStatus(
+                input_gcs_source="gs://test-directory/documentai/input.pdf",
+                output_gcs_destination="gs://documentai_toolbox_samples/output/matching-prefixes/11",
+            ),
+        ],
+    )
+    wrapped_document = quickstart_sample.quickstart_sample(
+        batch_process_metadata=batch_process_metadata
+    )
+
+    assert (
+        wrapped_document.gcs_prefix
+        == "gs://documentai_toolbox_samples/output/matching-prefixes/1/"
+    )
+    out, _ = capsys.readouterr()
+
+    assert "Document Successfully Loaded!" in out
+
+
 def test_quickstart_sample_batch_process_operation(
     capsys: pytest.CaptureFixture,
 ) -> None:

--- a/samples/snippets/test_quickstart_sample.py
+++ b/samples/snippets/test_quickstart_sample.py
@@ -116,10 +116,7 @@ def test_quickstart_sample_batch_process_metadata_matching_prefixes(
         batch_process_metadata=batch_process_metadata
     )
 
-    assert (
-        wrapped_document.gcs_prefix
-        == "gs://documentai_toolbox_samples/output/matching-prefixes/1/"
-    )
+    assert wrapped_document.gcs_prefix == "output/matching-prefixes/1/"
     out, _ = capsys.readouterr()
 
     assert "Document Successfully Loaded!" in out


### PR DESCRIPTION
Fixes #271 🦕
