### PR TITLE
fix: Revert setup.py for`google-api-core` to `2.15.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
         "google.cloud.documentai_toolbox": ["templates/*.xml.j2"],
     },
     install_requires=(
-        "google-api-core>=2.17.1, <3.0.0dev",
+        "google-api-core>=2.15.0, <3.0.0dev",
         "pandas[performance,gcp]>=2.0.0, <3.0.0",
         "pyarrow>=15.0.0, <16.0.0",
         "tabulate>=0.9.0, <1.0.0",

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -5,7 +5,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==2.17.1
+google-api-core==2.15.0
 pandas==2.0.0
 proto-plus==1.22.3
 grpc-google-iam-v1==0.12.6


### PR DESCRIPTION
When I was locally testing fixes for another PR, I was getting these types of reports from pip.

```ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
langchain-google-vertexai 0.0.6rc0 requires google-cloud-storage<3.0.0,>=2.14.0, but you have google-cloud-storage 2.14.0rc1 which is incompatible.
```

I thought it was strange that I had a release candidate version of google-cloud-storage, so I tried upgrading, but then I got this error:

```ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
google-cloud-documentai-toolbox 0.13.2a0 requires google-api-core<3.0.0dev,>=2.17.1, but you have google-api-core 2.15.0 which is incompatible.
```

This makes me think that the latest version of `google-cloud-storage` currently requires `google-api-core==2.15.0`