### PR TITLE
fix: Change `if` condition typo in `_get_children_of_element()`

### DIFF
--- a/google/cloud/documentai_toolbox/wrappers/page.py
+++ b/google/cloud/documentai_toolbox/wrappers/page.py
@@ -359,9 +359,11 @@ def _get_children_of_element(
     return [
         child
         for child in children
-        if child.documentai_object.layout.text_anchor.text_segments[0].start_index
-        >= start_index
-        if child.documentai_object.layout.text_anchor.text_segments[0].end_index
+        if start_index
+        <= child.layout.text_anchor.text_segments[0].start_index
+        < end_index
+        and start_index
+        < child.layout.text_anchor.text_segments[0].end_index
         <= end_index
     ]
 

--- a/google/cloud/documentai_toolbox/wrappers/page.py
+++ b/google/cloud/documentai_toolbox/wrappers/page.py
@@ -363,7 +363,7 @@ def _get_children_of_element(
         <= child.documentai_object.layout.text_anchor.text_segments[0].start_index
         < end_index
         and start_index
-        < child.documentai_object.text_anchor.text_segments[0].end_index
+        < child.documentai_object.layout.text_anchor.text_segments[0].end_index
         <= end_index
     ]
 

--- a/google/cloud/documentai_toolbox/wrappers/page.py
+++ b/google/cloud/documentai_toolbox/wrappers/page.py
@@ -360,10 +360,10 @@ def _get_children_of_element(
         child
         for child in children
         if start_index
-        <= child.layout.text_anchor.text_segments[0].start_index
+        <= child.documentai_object.layout.text_anchor.text_segments[0].start_index
         < end_index
         and start_index
-        < child.layout.text_anchor.text_segments[0].end_index
+        < child.documentai_object.text_anchor.text_segments[0].end_index
         <= end_index
     ]
 


### PR DESCRIPTION
The previous `if` condition was inefficient and should have been written with an `and` This resulted in a performance gap.

cProfile timing of `export_hocr_string()` on the same document

Before
```
143598720 function calls (129111346 primitive calls) in 44.487 seconds
```

After

```
97883150 function calls (88084552 primitive calls) in 30.235 seconds
```


Fixes #312 🦕
